### PR TITLE
Feature/cart discounts

### DIFF
--- a/app/controllers/user/orders_controller.rb
+++ b/app/controllers/user/orders_controller.rb
@@ -13,11 +13,19 @@ class User::OrdersController < ApplicationController
     order = current_user.orders.new
     order.save
       cart.items.each do |item|
-        order.order_items.create({
-          item: item,
-          quantity: cart.count_of(item.id),
-          price: item.price
-          })
+        if item.eligible_discount(cart.count_of(item.id))
+          order.order_items.create({
+            item: item,
+            quantity: cart.count_of(item.id),
+            price: item.adjusted_price
+            })
+        else
+          order.order_items.create({
+            item: item,
+            quantity: cart.count_of(item.id),
+            price: item.price
+            })
+        end
       end
     session.delete(:cart)
     flash[:notice] = "Order created successfully!"

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -40,6 +40,10 @@ class Cart
     @contents[item_id.to_s] * Item.find(item_id).price
   end
 
+  def discounted_subtotal_of(item_id)
+    @contents[item_id.to_s] * Item.find(item_id).adjusted_price
+  end
+
   def limit_reached?(item_id)
     count_of(item_id) == Item.find(item_id).inventory
   end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -24,10 +24,23 @@ class Cart
     end
   end
 
+  def subtotal
+    total = 0.0
+    @contents.each do |item_id, quantity|
+      total += Item.find(item_id).price * quantity
+    end
+    total
+  end
+
   def grand_total
     grand_total = 0.0
     @contents.each do |item_id, quantity|
-      grand_total += Item.find(item_id).price * quantity
+      item = Item.find(item_id)
+      if item.eligible_discount(quantity)
+        grand_total += item.adjusted_price * quantity
+      else
+        grand_total += item.price * quantity
+      end
     end
     grand_total
   end
@@ -40,8 +53,8 @@ class Cart
     @contents[item_id.to_s] * Item.find(item_id).price
   end
 
-  def discounted_subtotal_of(item_id)
-    @contents[item_id.to_s] * Item.find(item_id).adjusted_price
+  def discounted_subtotal_of(item)
+    @contents[item.id.to_s] * item.adjusted_price
   end
 
   def limit_reached?(item_id)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,6 +2,7 @@ class Item < ApplicationRecord
   belongs_to :merchant
   has_many :order_items
   has_many :orders, through: :order_items
+  has_many :discounts, through: :merchant
   has_many :reviews, dependent: :destroy
 
   validates_presence_of :name,
@@ -28,5 +29,13 @@ class Item < ApplicationRecord
 
   def average_rating
     reviews.average(:rating)
+  end
+
+  def eligible_discount(quantity)
+    discounts.where('quantity <= ?', quantity).order(:rate).last
+  end
+
+  def adjusted_price
+
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,6 @@
 class Item < ApplicationRecord
+  attr_reader :discount
+
   belongs_to :merchant
   has_many :order_items
   has_many :orders, through: :order_items
@@ -32,10 +34,10 @@ class Item < ApplicationRecord
   end
 
   def eligible_discount(quantity)
-    discounts.where('quantity <= ?', quantity).order(:rate).last
+    @discount = discounts.where('quantity <= ?', quantity).order(:rate).last
   end
 
   def adjusted_price
-
+    price * (1 - (@discount.rate / 100))
   end
 end

--- a/app/views/cart/show.html.erb
+++ b/app/views/cart/show.html.erb
@@ -2,7 +2,8 @@
 <% if cart.items.empty? %>
   <p>Your Cart is Empty!</p>
 <% else %>
-<h3>Total: <%= number_to_currency(cart.grand_total) %></h3>
+<h3>Subtotal: <%= number_to_currency(cart.subtotal) %></h3>
+<h3>Grand Total: <%= number_to_currency(cart.grand_total) %></h3>
   <% cart.items.each do |item| %>
     <section id='item-<%= item.id%>'>
       <h2><%= link_to item.name, "/items/#{item.id}" %></h2>
@@ -10,8 +11,10 @@
       <p>Price: <%= number_to_currency(item.price) %></p>
       <p>Quantity: <%= cart.count_of(item.id) %></p>
       <p>Subtotal: <%= number_to_currency(cart.subtotal_of(item.id)) %></p>
-      <% if discount = item.eligible_discount(cart.count_of(item.id)) %>
-        <p>Discount Applied: <%= number_to_percentage(discount.rate, precision: 1) %> discount on <%= discount.quantity %> or more items</p>
+      <% if item.eligible_discount(cart.count_of(item.id)) %>
+        <p>Discount Applied: <%= number_to_percentage(item.discount.rate, precision: 1) %> discount on <%= item.discount.quantity %> or more items</p>
+        <p>Adjusted Item Price: <%= number_to_currency(item.adjusted_price) %></p>
+        <p>Discounted Subtotal: <%= number_to_currency(cart.discounted_subtotal_of(item)) %></p>
       <% end %>
       <p>Sold by: <%= link_to item.merchant.name, "/merchants/#{item.merchant_id}" %>, Inventory: <%= item.inventory %></p>
       <%= button_to 'More of This!', "/cart/more/#{item.id}", method: :patch unless cart.limit_reached?(item.id) %>

--- a/app/views/cart/show.html.erb
+++ b/app/views/cart/show.html.erb
@@ -10,6 +10,9 @@
       <p>Price: <%= number_to_currency(item.price) %></p>
       <p>Quantity: <%= cart.count_of(item.id) %></p>
       <p>Subtotal: <%= number_to_currency(cart.subtotal_of(item.id)) %></p>
+      <% if discount = item.eligible_discount(cart.count_of(item.id)) %>
+        <p>Discount Applied: <%= number_to_percentage(discount.rate, precision: 1) %> discount on <%= discount.quantity %> or more items</p>
+      <% end %>
       <p>Sold by: <%= link_to item.merchant.name, "/merchants/#{item.merchant_id}" %>, Inventory: <%= item.inventory %></p>
       <%= button_to 'More of This!', "/cart/more/#{item.id}", method: :patch unless cart.limit_reached?(item.id) %>
       <%= button_to 'Less of This!', "/cart/less/#{item.id}", method: :patch %>

--- a/app/views/merchant/discounts/index.html.erb
+++ b/app/views/merchant/discounts/index.html.erb
@@ -14,8 +14,8 @@
   <tbody>
     <% @discounts.each do |discount| %>
       <tr id="discount-<%= discount.id %>">
-        <td><%= number_to_percentage(discount.rate, precision: 1) %></td>
-        <td><%= discount.quantity %></td>
+        <td><%= number_to_percentage(discount.rate, precision: 1) %> discount</td>
+        <td>on <%= discount.quantity %> or more items</td>
         <td><%= link_to 'Show', merchant_discount_path(discount) %></td>
         <td><%= link_to 'Edit', edit_merchant_discount_path(discount) %></td>
         <td><%= link_to 'Delete', merchant_discount_path(discount), method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/merchant/discounts/show.html.erb
+++ b/app/views/merchant/discounts/show.html.erb
@@ -2,12 +2,12 @@
 
 <p>
   <strong>Rate:</strong>
-  <%= number_to_percentage(@discount.rate, precision: 1) %>
+  <%= number_to_percentage(@discount.rate, precision: 1) %> discount
 </p>
 
 <p>
   <strong>Quantity:</strong>
-  <%= @discount.quantity %>
+  On <%= @discount.quantity %> or more items
 </p>
 
 <p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  get :root, to: 'welcome#index'
+  root 'welcome#index'
 
   resources :merchants do
     resources :items, only: [:index]

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -52,5 +52,24 @@ FactoryBot.define do
         create_list(:discount, evaluator.discounts, merchant: merchant)
       end
     end
+
+    trait :with_items do
+      transient do
+        items { 3 }
+      end
+
+      after :create do |merchant, evaluator|
+        create_list(:item, evaluator.items, merchant: merchant)
+      end
+    end
+  end
+
+  factory :item do
+    name { Faker::Commerce.product_name }
+    description { Faker::Lorem.sentence }
+    price { Faker::Commerce.price }
+    image { 'https://placeimg.com/640/480/animals' }
+    inventory { rand(10..50) }
+    merchant
   end
 end

--- a/spec/features/cart/discounts_spec.rb
+++ b/spec/features/cart/discounts_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe "Cart Discounts" do
 
         within "#item-#{@merchant_1.items.first.id}" do
           expect(page).to have_content("Discount Applied: #{number_to_percentage(@discount_1.rate, precision: 1)} discount on #{@discount_1.quantity} or more items")
+          expect(page).to have_content("Adjusted Item Price: #{number_to_currency(@merchant_1.items.first.price * (1 - (@discount_1.rate / 100)))}")
+          expect(page).to have_content("Discounted Subtotal: #{number_to_currency(@merchant_1.items.first.price * (1 - (@discount_1.rate / 100)) * 2)}")
         end
       end
 
@@ -42,6 +44,8 @@ RSpec.describe "Cart Discounts" do
 
         within "#item-#{@merchant_1.items.second.id}" do
           expect(page).to_not have_content("Discount Applied: ")
+          expect(page).to_not have_content("Adjusted Item Price: ")
+          expect(page).to_not have_content("Discounted Subtotal: ")
         end
       end
 
@@ -50,10 +54,14 @@ RSpec.describe "Cart Discounts" do
 
         within "#item-#{@merchant_2.items.first.id}" do
           expect(page).to_not have_content("Discount Applied: ")
+          expect(page).to_not have_content("Adjusted Item Price: ")
+          expect(page).to_not have_content("Discounted Subtotal: ")
         end
 
         within "#item-#{@merchant_2.items.second.id}" do
           expect(page).to_not have_content("Discount Applied: ")
+          expect(page).to_not have_content("Adjusted Item Price: ")
+          expect(page).to_not have_content("Discounted Subtotal: ")
         end
       end
 
@@ -67,6 +75,8 @@ RSpec.describe "Cart Discounts" do
 
           within "#item-#{@merchant_1.items.first.id}" do
             expect(page).to have_content("Discount Applied: #{number_to_percentage(@discount_2.rate, precision: 1)} discount on #{@discount_2.quantity} or more items")
+            expect(page).to have_content("Adjusted Item Price: #{number_to_currency(@merchant_1.items.first.price * (1 - (@discount_2.rate / 100)))}")
+            expect(page).to have_content("Discounted Subtotal: #{number_to_currency(@merchant_1.items.first.price * (1 - (@discount_2.rate / 100)) * 2)}")
           end
         end
 
@@ -75,6 +85,8 @@ RSpec.describe "Cart Discounts" do
 
           within "#item-#{@merchant_1.items.first.id}" do
             expect(page).to_not have_content("Discount Applied: #{number_to_percentage(@discount_1.rate, precision: 1)} discount on #{@discount_1.quantity} or more items")
+            expect(page).to_not have_content("Adjusted Item Price: #{number_to_currency(@merchant_1.items.first.price * (1 - (@discount_1.rate / 100)))}")
+            expect(page).to_not have_content("Discounted Subtotal: #{number_to_currency(@merchant_1.items.first.price * (1 - (@discount_1.rate / 100)) * 2)}")
           end
         end
       end
@@ -91,6 +103,8 @@ RSpec.describe "Cart Discounts" do
 
         within "#item-#{@merchant_1.items.second.id}" do
           expect(page).to_not have_content("Discount Applied: ")
+          expect(page).to_not have_content("Adjusted Item Price: ")
+          expect(page).to_not have_content("Discounted Subtotal: ")
         end
       end
 
@@ -104,10 +118,14 @@ RSpec.describe "Cart Discounts" do
 
           within "#item-#{@merchant_1.items.first.id}" do
             expect(page).to_not have_content("Discount Applied: ")
+            expect(page).to_not have_content("Adjusted Item Price: ")
+            expect(page).to_not have_content("Discounted Subtotal: ")
           end
 
           within "#item-#{@merchant_1.items.second.id}" do
             expect(page).to_not have_content("Discount Applied: ")
+            expect(page).to_not have_content("Adjusted Item Price: ")
+            expect(page).to_not have_content("Discounted Subtotal: ")
           end
         end
       end

--- a/spec/features/cart/discounts_spec.rb
+++ b/spec/features/cart/discounts_spec.rb
@@ -1,0 +1,116 @@
+require 'rails_helper'
+include ActionView::Helpers::NumberHelper
+
+RSpec.describe "Cart Discounts" do
+  describe "As a Visitor" do
+    before :each do
+      @merchant_1 = create(:merchant, :with_items)
+      @discount_1 = create(:discount, rate: 10, quantity: 2, merchant: @merchant_1)
+    end
+
+    describe "When I add enough of a single item" do
+      before :each do
+        @merchant_2 = create(:merchant, :with_items)
+
+        2.times do
+          visit item_path(@merchant_1.items.first)
+          click_button 'Add to Cart'
+        end
+
+        visit item_path(@merchant_1.items.second)
+        click_button 'Add to Cart'
+
+        2.times do
+          visit item_path(@merchant_2.items.first)
+          click_button 'Add to Cart'
+        end
+
+        visit item_path(@merchant_2.items.second)
+        click_button 'Add to Cart'
+      end
+
+      it 'I see a discount applied to that item' do
+        visit '/cart'
+
+        within "#item-#{@merchant_1.items.first.id}" do
+          expect(page).to have_content("Discount Applied: #{number_to_percentage(@discount_1.rate, precision: 1)} discount on #{@discount_1.quantity} or more items")
+        end
+      end
+
+      it 'I do not see a discount applied to other items with same merchant' do
+        visit '/cart'
+
+        within "#item-#{@merchant_1.items.second.id}" do
+          expect(page).to_not have_content("Discount Applied: ")
+        end
+      end
+
+      it 'I do not see a discount applied to other items with different merchant' do
+        visit '/cart'
+
+        within "#item-#{@merchant_2.items.first.id}" do
+          expect(page).to_not have_content("Discount Applied: ")
+        end
+
+        within "#item-#{@merchant_2.items.second.id}" do
+          expect(page).to_not have_content("Discount Applied: ")
+        end
+      end
+
+      describe "And there are multiple discounts" do
+        before :each do
+          @discount_2 = create(:discount, rate: 15, quantity: 2, merchant: @merchant_1)
+        end
+
+        it 'I see the greatest discount applied' do
+          visit '/cart'
+
+          within "#item-#{@merchant_1.items.first.id}" do
+            expect(page).to have_content("Discount Applied: #{number_to_percentage(@discount_2.rate, precision: 1)} discount on #{@discount_2.quantity} or more items")
+          end
+        end
+
+        it 'I do not see the lesser discounts applied' do
+          visit '/cart'
+
+          within "#item-#{@merchant_1.items.first.id}" do
+            expect(page).to_not have_content("Discount Applied: #{number_to_percentage(@discount_1.rate, precision: 1)} discount on #{@discount_1.quantity} or more items")
+          end
+        end
+      end
+    end
+
+    describe "When I don't have enough of a single item" do
+      before :each do
+        visit item_path(@merchant_1.items.second)
+        click_button 'Add to Cart'
+      end
+
+      it 'I do not see a discount applied to that item' do
+        visit '/cart'
+
+        within "#item-#{@merchant_1.items.second.id}" do
+          expect(page).to_not have_content("Discount Applied: ")
+        end
+      end
+
+      describe "But, I have multiple merchant items" do
+        before :each do
+          visit item_path(@merchant_1.items.first)
+          click_button 'Add to Cart'
+        end
+        it 'I do not see a discount applied to any item' do
+          visit '/cart'
+
+          within "#item-#{@merchant_1.items.first.id}" do
+            expect(page).to_not have_content("Discount Applied: ")
+          end
+
+          within "#item-#{@merchant_1.items.second.id}" do
+            expect(page).to_not have_content("Discount Applied: ")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/user/orders/create_spec.rb
+++ b/spec/features/user/orders/create_spec.rb
@@ -9,11 +9,12 @@ RSpec.describe 'Create Order' do
       @ogre = @megan.items.create!(name: 'Ogre', description: "I'm an Ogre!", price: 20, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 5 )
       @giant = @megan.items.create!(name: 'Giant', description: "I'm a Giant!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 3 )
       @hippo = @brian.items.create!(name: 'Hippo', description: "I'm a Hippo!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 3 )
+
+      @discount_1 = create(:discount, rate: 10, quantity: 2, merchant: @brian)
+
       @user = User.create!(name: 'Megan', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218, email: 'megan@example.com', password: 'securepassword')
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
-    end
 
-    it 'I can click a link to get to create an order' do
       visit item_path(@ogre)
       click_button 'Add to Cart'
       visit item_path(@hippo)
@@ -22,7 +23,9 @@ RSpec.describe 'Create Order' do
       click_button 'Add to Cart'
 
       visit '/cart'
+    end
 
+    it 'I can click a link to get to create an order' do
       click_button 'Check Out'
 
       order = Order.last
@@ -34,6 +37,22 @@ RSpec.describe 'Create Order' do
       within "#order-#{order.id}" do
         expect(page).to have_link(order.id)
       end
+    end
+
+    it "I can create an order with discounts, and see on the order show page" do
+      click_button 'Check Out'
+
+      order = Order.last
+
+      within "#order-#{order.id}" do
+        click_link order.id
+      end
+
+      expect(current_path).to eq("/profile/orders/#{order.id}")
+
+      expect(page).to have_link("Hippo")
+      expect(page).to have_content("Price: $45.00")
+      expect(page).to_not have_content("Price: $50.00")
     end
   end
 

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe Cart do
       @ogre = @megan.items.create!(name: 'Ogre', description: "I'm an Ogre!", price: 20, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 5 )
       @giant = @megan.items.create!(name: 'Giant', description: "I'm a Giant!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 2 )
       @hippo = @brian.items.create!(name: 'Hippo', description: "I'm a Hippo!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 3 )
+
+      @discount = create(:discount, rate: 10, quantity: 2, merchant: @megan)
+
       @cart = Cart.new({
         @ogre.id.to_s => 1,
         @giant.id.to_s => 2
@@ -39,8 +42,12 @@ RSpec.describe Cart do
       expect(@cart.items).to eq([@ogre, @giant])
     end
 
+    it '.subtotal' do
+      expect(@cart.subtotal).to eq(120)
+    end
+
     it '.grand_total' do
-      expect(@cart.grand_total).to eq(120)
+      expect(@cart.grand_total).to eq(110)
     end
 
     it '.count_of()' do
@@ -51,6 +58,11 @@ RSpec.describe Cart do
     it '.subtotal_of()' do
       expect(@cart.subtotal_of(@ogre.id)).to eq(20)
       expect(@cart.subtotal_of(@giant.id)).to eq(100)
+    end
+
+    it '.discounted_subtotal_of()' do
+      expect(@giant.eligible_discount(2)).to eq(@discount)
+      expect(@cart.discounted_subtotal_of(@giant)).to eq(90)
     end
 
     it '.limit_reached?()' do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Item do
     it {should belong_to :merchant}
     it {should have_many :order_items}
     it {should have_many(:orders).through(:order_items)}
+    it {should have_many(:discounts).through(:merchant)}
     it {should have_many :reviews}
   end
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe Item do
       @review_3 = @ogre.reviews.create(title: 'EW', description: 'This Ogre is Ew', rating: 1)
       @review_4 = @ogre.reviews.create(title: 'So So', description: 'This Ogre is So so', rating: 2)
       @review_5 = @ogre.reviews.create(title: 'Okay', description: 'This Ogre is Okay', rating: 4)
+
+      @discount_1 = create(:discount, rate: 10, quantity: 2, merchant: @megan)
+      @discount_2 = create(:discount, rate: 15, quantity: 3, merchant: @megan)
+      @discount_3 = create(:discount, rate: 20, quantity: 3, merchant: @megan)
     end
 
     it '.sorted_reviews()' do
@@ -37,6 +41,19 @@ RSpec.describe Item do
 
     it '.average_rating' do
       expect(@ogre.average_rating.round(2)).to eq(3.00)
+    end
+
+    it '.eligible_discount' do
+      expect(@ogre.eligible_discount(1)).to eq(nil)
+      expect(@ogre.eligible_discount(2)).to eq(@discount_1)
+      expect(@ogre.eligible_discount(3)).to_not eq(@discount_2)
+      expect(@ogre.eligible_discount(3)).to eq(@discount_3)
+    end
+
+    it '.adjusted_price' do
+      expect(@ogre.eligible_discount(2)).to eq(@discount_1)
+      expect(@ogre.adjusted_price).to eq(18)
+      expect(@ogre.adjusted_price).to_not eq(@ogre.price)
     end
   end
 


### PR DESCRIPTION
This PR:

- Handles discounts being applied in a cart after reaching the merchant discount quantity when there are enough of that merchant item
- Creates methods that handle applying the discount, including creating a virtual attribute of discount for the item model.
- Ensures cart show and order show pages show all final discounted prices
- Creates robust and passing feature and model tests for all functionality


Completes Criteria: 
- [x] When a user adds enough quantity of a single item to their cart, the bulk discount will automatically show up on the cart page.
- [x] A bulk discount from one merchant will only affect items from that merchant in the cart.
- [x] A bulk discount will only apply to items which exceed the minimum quantity specified in the bulk discount. (eg, a 5% off 5 items or more does not activate if a user is buying 1 quantity of 5 different items; if they raise the quantity of one item to 5, then the bulk discount is only applied to that one item, not all of the others as well)
- [x] When there is a conflict between two discounts, the greater of the two will be applied.
- [x] Final discounted prices should appear on the orders show page.